### PR TITLE
Support jsonp [with encoding]

### DIFF
--- a/modules/PackageUtils.js
+++ b/modules/PackageUtils.js
@@ -11,7 +11,10 @@ const decodeParam = (param) =>
 
 const ValidQueryKeys = {
   main: true,
-  json: true
+  json: true,
+  jsonp: true,
+  callback: true,
+  encoding: true
 }
 
 const queryIsValid = (query) =>
@@ -32,10 +35,16 @@ export const parsePackageURL = (url) => {
   const version = decodeParam(match[2]) || 'latest'
   const filename = decodeParam(match[3])
 
-  return {        // If the URL is /@scope/name@version/path.js?main=browser:
+  const jsonpOpts = query.callback || query.jsonp ? {
+    callback: query.callback || query.jsonp,
+    encoding: query.encoding
+  } : null
+
+  return {        // If the URL is /@scope/name@version/path.js?main=browser&callback=cb&encoding=utf8:
     pathname,     // /@scope/name@version/path.js
     search,       // ?main=browser
     query,        // { main: 'browser' }
+    jsonpOpts,        // { callback: 'cb', encoding: 'uf8' }
     packageName,  // @scope/name
     version,      // version
     filename      // /path.js


### PR DESCRIPTION
Implements #67 

```
http://localhost:8080/typescript@2.2.1?jsonp=tt
```

produces
```
tt("/*! *****************************************************************************\nCopyright (c) Microsoft Corporation. All rights reserved. \nLice . . . 
```

Limitations and further features to add:
* sendFile in JSONP mode buffers content instead of piping (because it needs to process encoding)
* callback is called with just text, it would be neat to pass package metadata in too
* would be nice to be able to retrieve a whole npm package
* errors in JSONP mode should really come with 200 OK, and pass error in the callback
* would be great support file listings in JSONP mode

But it already does the job. One can fetch files from npm packages in restricted origins (like `file://`) -- such as fonts, CSS, HTML and so on.

Please review. I am open to any suggestions, tidying up to fit preferred style etc.